### PR TITLE
Feature/add health metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 
 BUILD_DIR := build
 
-build:
+build: clean
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-X 'main.Version=$(VERSION)' -X 'main.CommitHash=$(COMMIT)' -X 'main.BuildTime=$(BUILD_TIME)'" -o $(BUILD_DIR)/389-ds-exporter
 
 docker: build

--- a/config.yml
+++ b/config.yml
@@ -69,7 +69,7 @@ ldap:
   # LDAP server URL in RFC-2255 format. For example:
   # "ldap://localhost:389" or "ldaps://remote-server"
   #
-  server_url: "ldap://192.168.250.30:389"
+  server_url: "ldap://localhost:389"
 
   # DN of the account used to authenticate with the LDAP server.
   #
@@ -77,7 +77,7 @@ ldap:
 
   # Password of the LDAP account.
   #
-  bind_pw: "Astra1234"
+  bind_pw: "12345678"
 
   # Maximum size of the LDAP connection pool.
   # Connections are created as needed and deleted when their lifetime or idle time is exceeded.

--- a/config.yml
+++ b/config.yml
@@ -69,7 +69,7 @@ ldap:
   # LDAP server URL in RFC-2255 format. For example:
   # "ldap://localhost:389" or "ldaps://remote-server"
   #
-  server_url: "ldap://localhost:389"
+  server_url: "ldap://192.168.250.30:389"
 
   # DN of the account used to authenticate with the LDAP server.
   #
@@ -77,41 +77,14 @@ ldap:
 
   # Password of the LDAP account.
   #
-  bind_pw: "12345678"
+  bind_pw: "Astra1234"
 
-  # The 'ldap.connection_pool' section describes the parameters for connecting to the LDAP server from which metrics will be collected.
-  # In most cases, these settings do not need to be changed.
-  connection_pool:
-
-    # Maximum size of the LDAP connection pool.
-    # Connections are created as needed and deleted when their lifetime or idle time is exceeded.
-    # Recommended and default value is 4. If set lower, metric collectors may block waiting for connections, slowing down the exporter.
-    # Values above 4 have no effect, as the current version of the exporter does not use more than 4 connections at once.
-    #
-    # connections_limit: 4
-
-    # Timeout in seconds for establishing a connection to the LDAP server.
-    # Prevents the connection attempt from hanging indefinitely.
-    # A zero or negative value means no timeout.
-    #
-    # dial_timeout: 1
-
-    # Number of retry attempts when connecting to the LDAP server.
-    # If the initial attempt fails, this number of retries will be made with delays between attempts.
-    # A value of 0 means no retries.
-    #
-    # retry_count: 0
-
-    # Delay in seconds between LDAP reconnection attempts (used with retry_count).
-    # A value of 0 means no delay between attempts.
-    #
-    # retry_delay: 1
-
-    # Timeout in seconds for checking if an existing connection is still alive.
-    # Before reusing a connection, the pool checks it by sending a basic query.
-    # A zero or negative value disables the timeout.
-    #
-    # connection_alive_timeout: 1
+  # Maximum size of the LDAP connection pool.
+  # Connections are created as needed and deleted when their lifetime or idle time is exceeded.
+  # Recommended and default value is 4. If set lower, metric collectors may block waiting for connections, slowing down the exporter.
+  # Values above 4 have no effect, as the current version of the exporter does not use more than 4 connections at once.
+  #
+  # pool_conn_limit: 4
 
 # The 'log' section defines logging parameters.
 log:

--- a/docs/config.md
+++ b/docs/config.md
@@ -91,13 +91,7 @@ ldap:
   server_url: "ldap://localhost:389"
   bind_dn: "cn=directory manager"
   bind_pw: "12345678"
-
-  connection_pool:
-    connections_limit: 4
-    dial_timeout: 1
-    retry_count: 0
-    retry_delay: 1
-    connection_alive_timeout: 1
+  pool_conn_limit: 4
 ```
 ### server_url
 LDAP server URI (e.g., ldap://localhost:389 or ldaps://example.com)
@@ -110,11 +104,7 @@ DN of the account used to authenticate with the LDAP server.
 ### bind_pw
 Password of the LDAP account.
 
-### connection_pool
-The 'ldap.connection_pool' section describes the parameters for connecting to the LDAP server from which metrics will be collected.
-In most cases, these settings do not need to be changed.
-
-### connections_limit:
+### pool_conn_limit:
 Maximum size of the LDAP connection pool.
 Connections are created as needed and deleted when their lifetime or idle time is exceeded.
 Recommended and default value is 4. If set lower, metric collectors may block waiting for connections, slowing down the exporter.
@@ -122,33 +112,6 @@ Values above 4 have no effect, as the current version of the exporter does not u
 
 Default value: `4`
 
-
-### dial_timeout:
-Timeout in seconds for establishing a connection to the LDAP server.
-Prevents the connection attempt from hanging indefinitely.
-A zero or negative value means no timeout.
-
-Default value: `1`
-
-### retry_count:
-Number of retry attempts when connecting to the LDAP server.
-If the initial attempt fails, this number of retries will be made with delays between attempts.
-A value of 0 means no retries.
-
-Default value: `0`
-
-### retry_delay:
-Delay in seconds between LDAP reconnection attempts (used with retry_count).
-A value of 0 means no delay between attempts.
-
-Default value: `1`
-
-### connection_alive_timeout:
-Timeout in seconds for checking if an existing connection is still alive.
-Before reusing a connection, the pool checks it by sending a basic query.
-A zero or negative value disables the timeout.
-
-Default value: `1`
 
 ## Logging
 The 'log' section defines logging parameters.

--- a/main.go
+++ b/main.go
@@ -400,6 +400,7 @@ func run() int {
 		BindDN:         cfg.LDAP.BindDN,
 		BindPw:         cfg.LDAP.BindPw,
 		MaxConnections: cfg.LDAP.GetPoolConnLimit(),
+		DialFunc:       network.RealConnectionDialUrl,
 	}
 
 	ldapConnPool := network.NewLdapConnectionPool(ldapConnPoolConfig)

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ var (
 
 const (
 	LogFileMode               os.FileMode   = 0o644
-	LdapConnectionPoolTimeout time.Duration = 5 * time.Second
+	LdapConnectionPoolTimeout time.Duration = 3 * time.Second
 )
 
 // appResources struct contains pointers to resources that must be closed when the program terminates.
@@ -351,20 +351,16 @@ func run() int {
 	)
 
 	ldapConnPoolConfig := network.LdapConnectionPoolConfig{
-		ServerURL:              cfg.LDAP.ServerURL,
-		BindDN:                 cfg.LDAP.BindDN,
-		BindPw:                 cfg.LDAP.BindPw,
-		MaxConnections:         cfg.LDAP.ConnectionPool.GetConnectionsLimit(),
-		DialTimeout:            time.Duration(cfg.LDAP.ConnectionPool.GetDialTimeout()) * time.Second,
-		RetryCount:             cfg.LDAP.ConnectionPool.GetRetryCount(),
-		RetryDelay:             time.Duration(cfg.LDAP.ConnectionPool.GetRetryDelay()) * time.Second,
-		ConnectionAliveTimeout: time.Duration(cfg.LDAP.ConnectionPool.GetConnectionAliveTimeout()) * time.Second,
+		ServerURL:      cfg.LDAP.ServerURL,
+		BindDN:         cfg.LDAP.BindDN,
+		BindPw:         cfg.LDAP.BindPw,
+		MaxConnections: cfg.LDAP.GetPoolConnLimit(),
 	}
 
 	ldapConnPool := network.NewLdapConnectionPool(ldapConnPoolConfig)
 	applicationResources.ConnPool = ldapConnPool
 
-	dsMetricsRegistry := setupPrometheusMetrics(cfg, ldapConnPool)
+	dsMetricsRegistry := setupPrometheusMetrics(cfg, applicationResources.ConnPool)
 
 	http.Handle(cfg.HTTP.GetMetricsPath(), promhttp.HandlerFor(dsMetricsRegistry, promhttp.HandlerOpts{}))
 	http.HandleFunc("/", defaultHttpResponse(cfg.HTTP.GetMetricsPath()))

--- a/src/collectors/ldap_collector.go
+++ b/src/collectors/ldap_collector.go
@@ -149,13 +149,6 @@ func (c *LdapEntryCollector) Collect(channel chan<- prometheus.Metric) {
 
 // getLdapEntryAttributes returs the record attributes specified in the LdapEntryCollector from the ldap.
 func (c *LdapEntryCollector) getLdapEntryAttributes() (map[string][]string, error) {
-	ldapConnection, err := c.connectionPool.Get(c.poolGetTimeout)
-	defer c.connectionPool.Put(ldapConnection)
-
-	if err != nil {
-		return nil, fmt.Errorf("error getting LDAP connection from pool: %w", err)
-	}
-
 	attributeList := make([]string, 0, len(c.attributes))
 
 	for _, monitoredAttr := range c.attributes {
@@ -174,7 +167,7 @@ func (c *LdapEntryCollector) getLdapEntryAttributes() (map[string][]string, erro
 		nil,
 	)
 
-	searchResult, err := ldapConnection.Search(searchAttributesRequest)
+	searchResult, err := c.connectionPool.Search(searchAttributesRequest, c.poolGetTimeout)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"LDAP Search request (dn='%v', attrs='%v') failed with error: %w",

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -37,18 +37,10 @@ type HTTPConfig struct {
 }
 
 type LDAPConfig struct {
-	ServerURL      string                   `yaml:"server_url"`
-	BindDN         string                   `yaml:"bind_dn"`
-	BindPw         string                   `yaml:"bind_pw"`
-	ConnectionPool LDAPConnectionPoolConfig `yaml:"connection_pool"`
-}
-
-type LDAPConnectionPoolConfig struct {
-	ConnectionsLimit       *int `yaml:"connections_limit"`        // Don't use these field directly.
-	DialTimeout            *int `yaml:"dial_timeout"`             // Don't use these field directly.
-	RetryCount             *int `yaml:"retry_count"`              // Don't use these field directly.
-	RetryDelay             *int `yaml:"retry_delay"`              // Don't use these field directly.
-	ConnectionAliveTimeout *int `yaml:"connection_alive_timeout"` // Don't use these field directly.
+	ServerURL     string `yaml:"server_url"`
+	BindDN        string `yaml:"bind_dn"`
+	BindPw        string `yaml:"bind_pw"`
+	PoolConnLimit *int   `yaml:"pool_conn_limit"`
 }
 
 type LoggingConfig struct {
@@ -75,15 +67,7 @@ func (c *ExporterConfiguration) String() string {
 	b.WriteString(fmt.Sprintf("ldap.server_url: %s\n", c.LDAP.ServerURL))
 	b.WriteString(fmt.Sprintf("ldap.bind_dn: %s\n", c.LDAP.BindDN))
 	b.WriteString(fmt.Sprintf("ldap.bind_pw: %s\n", "*****"))
-	b.WriteString(fmt.Sprintf("ldap.connection_pool.connections_limit: %d\n", c.LDAP.ConnectionPool.GetConnectionsLimit()))
-	b.WriteString(fmt.Sprintf("ldap.connection_pool.dial_timeout: %d\n", c.LDAP.ConnectionPool.GetDialTimeout()))
-	b.WriteString(fmt.Sprintf("ldap.connection_pool.retry_count: %d\n", c.LDAP.ConnectionPool.GetRetryCount()))
-	b.WriteString(fmt.Sprintf("ldap.connection_pool.retry_delay: %d\n", c.LDAP.ConnectionPool.GetRetryDelay()))
-	b.WriteString(
-		fmt.Sprintf(
-			"ldap.connection_pool.connection_alive_timeout: %d\n",
-			c.LDAP.ConnectionPool.GetConnectionAliveTimeout()),
-	)
+	b.WriteString(fmt.Sprintf("ldap.pool_conn_limit: %d\n", c.LDAP.PoolConnLimit))
 	b.WriteString(fmt.Sprintf("log.level: %s\n", c.Logging.GetLevel()))
 	b.WriteString(fmt.Sprintf("log.handler: %s\n", c.Logging.GetHandler()))
 	b.WriteString(fmt.Sprintf("log.file: %s\n", c.Logging.GetFile()))
@@ -103,54 +87,14 @@ func (c *GlobalConfig) GetShutdownTimeout() int {
 	return *c.ShutdownTimeout
 }
 
-// GetConnectionsLimit func return LDAPConnectionPoolConfig.ConnectionsLimit if it defined.
-// Else returns config.DefaultPoolConnectionsLimit constant.
-func (c *LDAPConnectionPoolConfig) GetConnectionsLimit() int {
-	if c.ConnectionsLimit == nil {
-		return DefaultLDAPPoolConnectionsLimit
+// GetPoolConnLimit func return LDAPConfig.GetPoolConnLimit if it defined.
+// Else returns config.DefaultLDAPPoolConnLimit constant.
+func (c *LDAPConfig) GetPoolConnLimit() int {
+	if c.PoolConnLimit == nil {
+		return DefaultLDAPPoolConnLimit
 	}
 
-	return *c.ConnectionsLimit
-}
-
-// GetDialTimeout func return LDAPConnectionPoolConfig.DialTimeout if it defined.
-// Else returns config.DefaultPoolDialTimeout constant.
-func (c *LDAPConnectionPoolConfig) GetDialTimeout() int {
-	if c.DialTimeout == nil {
-		return DefaultLDAPPoolDialTimeout
-	}
-
-	return *c.DialTimeout
-}
-
-// GetRetryCount func return LDAPConnectionPoolConfig.RetryCount if it defined.
-// Else returns config.DefaultPoolRetryCount constant.
-func (c *LDAPConnectionPoolConfig) GetRetryCount() int {
-	if c.RetryCount == nil {
-		return DefaultLDAPPoolRetryCount
-	}
-
-	return *c.RetryCount
-}
-
-// GetRetryDelay func return LDAPConnectionPoolConfig.RetryDelay if it defined.
-// Else returns config.DefaultPoolRetryDelay constant.
-func (c *LDAPConnectionPoolConfig) GetRetryDelay() int {
-	if c.RetryDelay == nil {
-		return DefaultLDAPPoolRetryDelay
-	}
-
-	return *c.RetryDelay
-}
-
-// GetConnectionAliveTimeout func return LDAPConnectionPoolConfig.ConnectionAliveTimeout if it defined.
-// Else returns config.DefaultLDAPPoolConnectionAliveTimeout constant.
-func (c *LDAPConnectionPoolConfig) GetConnectionAliveTimeout() int {
-	if c.ConnectionAliveTimeout == nil {
-		return DefaultLDAPPoolConnectionAliveTimeout
-	}
-
-	return *c.ConnectionAliveTimeout
+	return *c.PoolConnLimit
 }
 
 // GetListenAddress func return HTTPConfig.ListenAddress if it defined.

--- a/src/config/config_defaults.go
+++ b/src/config/config_defaults.go
@@ -8,10 +8,8 @@ const (
 	DefaultHTTPWriteTimeout               int    = 15
 	DefaultHTTPIdleTimeout                int    = 60
 	DefaultHTTPInitialReadTimeout         int    = 3
-	DefaultLDAPPoolConnectionsLimit       int    = 4
+	DefaultLDAPPoolConnLimit              int    = 4
 	DefaultLDAPPoolDialTimeout            int    = 1
-	DefaultLDAPPoolRetryCount             int    = 1
-	DefaultLDAPPoolRetryDelay             int    = 1
 	DefaultLDAPPoolConnectionAliveTimeout int    = 1
 	DefaultLogLevel                       string = "INFO"
 	DefaultLogHandler                     string = "both"

--- a/src/config/config_read.go
+++ b/src/config/config_read.go
@@ -34,8 +34,8 @@ func (c *ExporterConfiguration) Validate() error {
 		return fmt.Errorf("invalid global.ds_backend_implement: '%q' (must be 'bdb' or 'mdb')", c.Global.BackendImplement)
 	}
 
-	if c.LDAP.ConnectionPool.GetConnectionsLimit() <= 0 {
-		return errors.New("invalid ldap.connection_pool.connections_limit: must be greater than 0")
+	if c.LDAP.GetPoolConnLimit() <= 0 {
+		return errors.New("invalid ldap.pool_conn_limit: must be greater than 0")
 	}
 
 	logLevels := []string{"DEBUG", "INFO", "WARNING", "ERROR"}

--- a/src/metrics/ldap_ldbm_database.go
+++ b/src/metrics/ldap_ldbm_database.go
@@ -220,7 +220,7 @@ func GetLdapMDBDatabaseLDBM() map[string]collectors.LdapMonitoredAttribute {
 		},
 		"commitrwtxn": {
 			LdapName: "commitrwtxn",
-			Help:     "LMDB Commited RW transactions",
+			Help:     "LMDB Committed RW transactions",
 			Type:     prometheus.GaugeValue,
 		},
 		"granttimerwtxn": {
@@ -250,7 +250,7 @@ func GetLdapMDBDatabaseLDBM() map[string]collectors.LdapMonitoredAttribute {
 		},
 		"commitrotxn": {
 			LdapName: "commitrotxn",
-			Help:     "LMDB Commited RO transactions",
+			Help:     "LMDB Committed RO transactions",
 			Type:     prometheus.GaugeValue,
 		},
 		"granttimerotxn": {

--- a/src/network/ldap_conn.go
+++ b/src/network/ldap_conn.go
@@ -1,0 +1,38 @@
+package network
+
+import (
+	"github.com/go-ldap/ldap/v3"
+)
+
+type LdapConn interface {
+	Bind(string, string) error
+	Search(*ldap.SearchRequest) (*ldap.SearchResult, error)
+	Unbind() error
+}
+
+type RealLdapConn struct {
+	conn *ldap.Conn
+}
+
+func (c *RealLdapConn) Bind(bind_dn string, bind_pw string) error {
+	return c.conn.Bind(bind_dn, bind_pw)
+}
+
+func (c *RealLdapConn) Search(req *ldap.SearchRequest) (*ldap.SearchResult, error) {
+	return c.conn.Search(req)
+}
+
+func (c *RealLdapConn) Unbind() error {
+	return c.conn.Unbind()
+}
+
+func RealConnectionDialUrl(url string) (LdapConn, error) {
+	conn, err := ldap.DialURL(url)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RealLdapConn{
+		conn: conn,
+	}, nil
+}

--- a/src/network/ldap_conn.go
+++ b/src/network/ldap_conn.go
@@ -4,28 +4,37 @@ import (
 	"github.com/go-ldap/ldap/v3"
 )
 
+// LdapConn defines an interface for interacting with an LDAP server.
+// It includes basic operations such as binding, searching, and unbinding.
 type LdapConn interface {
 	Bind(string, string) error
 	Search(*ldap.SearchRequest) (*ldap.SearchResult, error)
 	Unbind() error
 }
 
+// RealLdapConn is a concrete implementation of the LdapConn interface,
+// using a real ldap.Conn from the go-ldap library.
 type RealLdapConn struct {
 	conn *ldap.Conn
 }
 
+// Bind authenticates to the LDAP server using the given bind DN and password.
 func (c *RealLdapConn) Bind(bind_dn string, bind_pw string) error {
 	return c.conn.Bind(bind_dn, bind_pw)
 }
 
+// Search executes the given LDAP search request and returns the result.
 func (c *RealLdapConn) Search(req *ldap.SearchRequest) (*ldap.SearchResult, error) {
 	return c.conn.Search(req)
 }
 
+// Unbind closes the LDAP connection.
 func (c *RealLdapConn) Unbind() error {
 	return c.conn.Unbind()
 }
 
+// RealConnectionDialUrl establishes a connection to the LDAP server using the given URL.
+// It returns an LdapConn interface backed by a real connection, or an error if the connection fails.
 func RealConnectionDialUrl(url string) (LdapConn, error) {
 	conn, err := ldap.DialURL(url)
 	if err != nil {


### PR DESCRIPTION
- Fixed LDAP connection closing (from conn.Close to conn.Unbind)
- Removed unused timeouts
- Added `/up` and `/health` endpoints
- Added LdapConn interface for future tests
- Simplified the logic of the LDAP pool